### PR TITLE
CMocka

### DIFF
--- a/cmake/mondradiko_create_test.cmake
+++ b/cmake/mondradiko_create_test.cmake
@@ -2,15 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 include (CTest)
-
-if (NOT CRITERION_FOUND)
-  include (FindPkgConfig)
-  pkg_check_modules (CRITERION criterion>=2.0)
-endif ()
+find_package (cmocka REQUIRED)
 
 function (mondradiko_create_test TEST_LIB TEST_NAME TEST_PATH)
   set (TEST_EXECUTABLE test-${TEST_NAME})
   add_executable (${TEST_EXECUTABLE} ${TEST_PATH})
-  target_link_libraries (${TEST_EXECUTABLE} ${TEST_LIB} ${CRITERION_LIBRARIES})
-  add_test (NAME ${TEST_NAME} COMMAND ${TEST_EXECUTABLE} --verbose)
+  target_link_libraries (${TEST_EXECUTABLE} ${TEST_LIB} cmocka)
+  add_test (NAME ${TEST_NAME} COMMAND ${TEST_EXECUTABLE})
 endfunction ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Marceline Cramer
+# SPDX-License-Identifier: MIT
+
 include (mondradiko_create_test)
 
 mondradiko_create_test (mdo-utils allocator test-allocator.c)

--- a/tests/test-allocator.c
+++ b/tests/test-allocator.c
@@ -10,27 +10,43 @@
 #define BUF_SIZE (1024)
 #define BUF_NUM (128)
 
-Test (allocator, malloc_and_free)
+static void
+test_malloc_and_free (void **state)
 {
   const mdo_allocator_t *alloc = mdo_default_allocator ();
   void *buf_data = mdo_allocator_malloc (alloc, BUF_SIZE);
-  cr_assert_not_null (buf_data);
+  assert_non_null (buf_data);
   mdo_allocator_free (alloc, buf_data);
 }
 
-Test (allocator, calloc_and_free)
+static void
+test_calloc_and_free (void **state)
 {
   const mdo_allocator_t *alloc = mdo_default_allocator ();
   void *buf_data = mdo_allocator_calloc (alloc, BUF_NUM, BUF_SIZE);
-  cr_assert_not_null (buf_data);
+  assert_non_null (buf_data);
   mdo_allocator_free (alloc, buf_data);
 }
 
-Test (allocator, realloc_and_free)
+static void
+test_realloc_and_free (void **state)
 {
   const mdo_allocator_t *alloc = mdo_default_allocator ();
   void *buf_data = mdo_allocator_malloc (alloc, BUF_SIZE);
-  cr_assert_not_null (buf_data);
+  assert_non_null (buf_data);
   buf_data = mdo_allocator_realloc (alloc, buf_data, BUF_SIZE * BUF_NUM);
+  assert_non_null (buf_data);
   mdo_allocator_free (alloc, buf_data);
+}
+
+int
+main (void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test (test_malloc_and_free),
+    cmocka_unit_test (test_calloc_and_free),
+    cmocka_unit_test (test_realloc_and_free),
+  };
+
+  return cmocka_run_group_tests (tests, NULL, NULL);
 }

--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -7,11 +7,22 @@
 
 #include "mondradiko/log.h"
 
-Test (log, log)
+static void
+test_log (void **state)
 {
   LOG_INF ("Info log message");
   LOG_DBG ("Debug log message");
   LOG_MSG ("User log message");
   LOG_WRN ("Warning log message");
   LOG_ERR ("Error log message");
+}
+
+int
+main (void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test (test_log),
+  };
+
+  return cmocka_run_group_tests (tests, NULL, NULL);
 }

--- a/tests/test-result.c
+++ b/tests/test-result.c
@@ -11,36 +11,32 @@
 #define FORMAT_LEN (256)
 
 static void
-cleanup ()
-{
-  mdo_result_cleanup ();
-}
-
-Test (result, cleanup) { mdo_result_cleanup (); }
-
-Test (result, constant_success, .fini = cleanup)
+test_constant_success (void **state)
 {
   int success = mdo_result_success (MDO_SUCCESS);
-  cr_assert (success);
+  assert_true (success);
 }
 
-Test (result, create_success, .fini = cleanup)
+static void
+test_create_success (void **state)
 {
   mdo_result_t result;
   result = mdo_result_create (MDO_LOG_INFO, "Success result", 0, true);
   int success = mdo_result_success (result);
-  cr_assert (success);
+  assert_true (success);
 }
 
-Test (result, create_error, .fini = cleanup)
+static void
+test_create_error (void **state)
 {
   mdo_result_t result;
   result = mdo_result_create (MDO_LOG_ERROR, "Error result", 0, false);
   int success = mdo_result_success (result);
-  cr_assert_not (success);
+  assert_false (success);
 }
 
-Test (result, format, .fini = cleanup)
+static void
+test_format (void **state)
 {
   mdo_result_t result;
   result = mdo_result_create (MDO_LOG_INFO, "Format: %d %d %d", 3, true);
@@ -52,12 +48,13 @@ Test (result, format, .fini = cleanup)
   int result_success = mdo_result_success (result);
   int format_success = mdo_result_success (format_result);
 
-  cr_assert (result_success);
-  cr_assert (format_success);
-  cr_assert_str_eq ("Format: 24 48 96", format);
+  assert_true (result_success);
+  assert_true (format_success);
+  assert_string_equal ("Format: 24 48 96", format);
 }
 
-Test (result, log, .fini = cleanup)
+static void
+test_log (void **state)
 {
   mdo_result_t result;
   result = mdo_result_create (MDO_LOG_INFO, "Format: %d %d %d", 3, true);
@@ -72,7 +69,21 @@ Test (result, log, .fini = cleanup)
   int result_success = mdo_result_success (result);
   int log_success = mdo_result_success (logged);
 
-  cr_assert (result_success);
-  cr_assert (log_success);
-  cr_assert_str_eq ("Format: 16 32 64", format);
+  assert_true (result_success);
+  assert_true (log_success);
+  assert_string_equal ("Format: 16 32 64", format);
+}
+
+int
+main (void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test (test_constant_success),
+    cmocka_unit_test (test_create_success),
+    cmocka_unit_test (test_create_error),
+    cmocka_unit_test (test_format),
+    cmocka_unit_test (test_log),
+  };
+
+  return cmocka_run_group_tests (tests, NULL, NULL);
 }

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,3 +1,7 @@
 #pragma once
 
-#include <criterion/criterion.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+#include <cmocka.h>


### PR DESCRIPTION
Replaces Criterion with CMocka, and swaps out pkg-config with a simple `find_package` call that is easy to use on Windows (bleh).